### PR TITLE
chore: pin to a fork of decimal so that updates don't break things

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,13 +6,13 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/Masterminds/sprig/v3 v3.2.2
 	github.com/davecgh/go-spew v1.1.1
-	github.com/ericlagergren/decimal v0.0.0-20181231230500-73749d4874d5
 	github.com/friendsofgo/errors v0.9.2
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/google/go-cmp v0.5.6
 	github.com/lib/pq v1.2.1-0.20191011153232-f91d3411e481
-	github.com/razor-1/null/v9 v9.0.5
 	github.com/microsoft/go-mssqldb v0.15.0
+	github.com/razor-1/decimal v0.1.1
+	github.com/razor-1/null/v9 v9.0.5
 	github.com/spf13/cast v1.4.1
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,6 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/ericlagergren/decimal v0.0.0-20181231230500-73749d4874d5 h1:HQGCJNlqt1dUs/BhtEKmqWd6LWS+DWYVxi9+Jo4r0jE=
-github.com/ericlagergren/decimal v0.0.0-20181231230500-73749d4874d5/go.mod h1:1yj25TwtUlJ+pfOu9apAVaM1RWfZGg+aFpd4hPQZekQ=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/friendsofgo/errors v0.9.2 h1:X6NYxef4efCBdwI7BgS820zFaN7Cphrmb+Pljdzjtgk=
@@ -306,6 +304,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSgv7Sy7s/s=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/razor-1/decimal v0.1.1 h1:adf9iy9ZBZE146/3meggw/bzjFRB5OQ8l9rwt6d0DYk=
+github.com/razor-1/decimal v0.1.1/go.mod h1:306Q3cqH4sJIGEkPRZHnI1HObmvY25A4NbmseRLubhg=
 github.com/razor-1/null/v9 v9.0.5 h1:z1f+cnaP+rLhtvxb4PFwWxWxOGfM5dxFZBFsVP7Q72o=
 github.com/razor-1/null/v9 v9.0.5/go.mod h1:6nDqgovgWceT8z9fyR7n5EQslgsPm7PsEj0MHgyKC5U=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 h1:OdAsTTz6OkFY5QxjkYwrChwuRruF69c169dPK26NUlk=

--- a/types/array.go
+++ b/types/array.go
@@ -33,8 +33,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ericlagergren/decimal"
 	"github.com/lib/pq/oid"
+	"github.com/razor-1/decimal"
 	"github.com/volatiletech/randomize"
 )
 

--- a/types/decimal.go
+++ b/types/decimal.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/ericlagergren/decimal"
+	"github.com/razor-1/decimal"
 )
 
 var (

--- a/types/decimal_test.go
+++ b/types/decimal_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ericlagergren/decimal"
+	"github.com/razor-1/decimal"
 	"github.com/razor-1/sqlboiler/v4/queries/qmhelper"
 )
 


### PR DESCRIPTION
Use a fork of ericlagergren/decimal so that doing `go get -u` on dependent projects won't update to a broken version