### PR TITLE
Improve handling of LoadJoin with multiple relationships

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/google/go-cmp v0.5.6
 	github.com/lib/pq v1.2.1-0.20191011153232-f91d3411e481
 	github.com/microsoft/go-mssqldb v0.15.0
-	github.com/paulmach/orb v0.9.2
+	github.com/paulmach/orb v0.10.0
 	github.com/razor-1/decimal v0.1.1
 	github.com/razor-1/null/v9 v9.0.5
 	github.com/spf13/cast v1.4.1

--- a/go.sum
+++ b/go.sum
@@ -297,6 +297,8 @@ github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FI
 github.com/paulmach/orb v0.9.0 h1:MwA1DqOKtvCgm7u9RZ/pnYejTeDJPnr0+0oFajBbJqk=
 github.com/paulmach/orb v0.9.0/go.mod h1:SudmOk85SXtmXAB3sLGyJ6tZy/8pdfrV0o6ef98Xc30=
 github.com/paulmach/orb v0.9.2/go.mod h1:5mULz1xQfs3bmQm63QEJA6lNGujuRafwA5S/EnuLaLU=
+github.com/paulmach/orb v0.10.0 h1:guVYVqzxHE/CQ1KpfGO077TR0ATHSNjp4s6XGLn3W9s=
+github.com/paulmach/orb v0.10.0/go.mod h1:5mULz1xQfs3bmQm63QEJA6lNGujuRafwA5S/EnuLaLU=
 github.com/paulmach/protoscan v0.2.1/go.mod h1:SpcSwydNLrxUGSDvXvO0P7g7AuhJ7lcKfDlhJCDw2gY=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pelletier/go-toml v1.9.4 h1:tjENF6MfZAg8e4ZmZTeWaWiT2vXtsoO6+iuOjFhECwM=

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/razor-1/sqlboiler/v4/importers"
 )
 
-const sqlBoilerVersion = "4.13.3-razor-1"
+const sqlBoilerVersion = "4.13.5-razor-1"
 
 var (
 	flagConfigFile string

--- a/templates/main/00_struct.go.tpl
+++ b/templates/main/00_struct.go.tpl
@@ -45,8 +45,9 @@ var {{$alias.UpSingular}}RelationshipColumns = relationMap{
 		{{- $relAlias := $alias.Relationship .Name -}}
         {{- $colAlias := $alias.Column .Column -}}
 		{{$alias.UpSingular}}Columns.{{$colAlias}}: {
-			Table: TableNames.{{titleCase .ForeignTable}},
-			Column: {{$fAlias.UpSingular}}Columns.{{index $fAlias.Columns .ForeignColumn}},
+			Table:    TableNames.{{titleCase .ForeignTable}},
+			Column:   {{$fAlias.UpSingular}}Columns.{{index $fAlias.Columns .ForeignColumn}},
+			Nullable: {{if .Nullable}}true{{else}}false{{end}},
 		},
 	{{end -}}
 }


### PR DESCRIPTION
We used to end up randomly selecting a relationship when there were multiple between the same tables. Now we prioritize the non-nullable and then fall back to alphabetical.