### PR TITLE
Automatically use ST_AsGeoJSON() for non-point spatial types

### DIFF
--- a/drivers/column.go
+++ b/drivers/column.go
@@ -2,6 +2,7 @@ package drivers
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/volatiletech/strmangle"
 )
@@ -36,6 +37,15 @@ type Column struct {
 	// tinyint(1) instead of tinyint
 	// Used for "tinyint-as-bool" flag
 	FullDBType string `json:"full_db_type" toml:"full_db_type"`
+}
+
+func (c Column) IsSpatialGeoJSON() bool {
+	switch strings.ToUpper(strings.TrimSpace(c.DBType)) {
+	// note that we specifically do not include POINT, because that's handled in types/mygeo
+	case "GEOMETRY", "LINESTRING", "POLYGON", "MULTIPOINT", "MULTILINESTRING", "MULTIPOLYGON", "GEOMETRYCOLLECTION":
+		return true
+	}
+	return false
 }
 
 // ColumnNames of the columns.

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 	"github.com/razor-1/sqlboiler/v4/importers"
 )
 
-const sqlBoilerVersion = "4.13.7"
+const sqlBoilerVersion = "4.13.8"
 
 var (
 	flagConfigFile string

--- a/templates/main/13_all.go.tpl
+++ b/templates/main/13_all.go.tpl
@@ -11,7 +11,20 @@ func {{$alias.UpPlural}}(mods ...qm.QueryMod) {{$alias.DownSingular}}Query {
 
     q := NewQuery(mods...)
     if len(queries.GetSelect(q)) == 0 {
-        queries.SetSelect(q, []string{"{{$schemaTable}}.*"})
+        if SpatialAsGeoJSON && len(SpatialTableColumns[TableNames.{{titleCase .Table.Name}}]) > 0 {
+            // if we have a spatial column, then we need to enumerate each column to account for it.
+            selectCols := make([]string, len({{$alias.DownSingular}}AllColumns))
+            copy(selectCols, {{$alias.DownSingular}}AllColumns)
+            for i, col := range selectCols {
+                if isSpatialGeoJSON(TableNames.{{titleCase .Table.Name}}, col) {
+                    selectCols[i] = fmt.Sprintf("ST_AsGeoJSON(`%s`) AS `%s`", col, col)
+                }
+            }
+            queries.SetSelect(q, selectCols)
+        } else {
+            // otherwise, we can use the ".*" shortcut.
+            queries.SetSelect(q, []string{"{{$schemaTable}}.*"})
+        }
     }
 
     return {{$alias.DownSingular}}Query{q}

--- a/templates/main/singleton/boil_table_names.go.tpl
+++ b/templates/main/singleton/boil_table_names.go.tpl
@@ -28,3 +28,16 @@ var TableNameToTableColumns = map[string][]string{
 	TableNames.{{titleCase $table.Name}}: {{$alias.DownSingular}}AllColumns,
 {{end -}}
 }
+
+var SpatialTableColumns = map[string]map[string]bool{
+{{range $table := .Tables -}}
+	{{- $alias := $.Aliases.Table $table.Name -}}
+	TableNames.{{titleCase $table.Name}}: {
+		{{- range $column := $table.Columns -}}
+			{{- if $column.IsSpatialGeoJSON }}
+				{{$alias.UpSingular}}Columns.{{$alias.Column $column.Name}}: true,
+			{{end -}}
+		{{end -}}
+	},
+{{end -}}
+}


### PR DESCRIPTION
Instead of having to deal with a bunch of manual query building, make all spatial types except `POINT` return GeoJSON.